### PR TITLE
CHICKEN Extension Packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 *~
+*.swp
+*.import.scm
+*.so
+salmonella.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# SRFI 117 - Mutable Queues
+
+This repository hosts a reference implementation of SRFI 117 - Mutable Queues. The full documentation for this SRFI can be found on the [SRFI Document Reference](http://srfi.schemers.org/srfi-117). The repository hosts a complete implementation of the SRFI, running on [CHICKEN](http://call-cc.org) Scheme.
+
+## File Description
+
+While this repository is primarily to provide a reference implementation of SRFI 117, it also currently serves as the base repository to host the library as a CHICKEN extension (egg). Thus, there are three files that are independent of the SRFI itself, and are as follows:
+
+`srfi-117.meta`
+: This file denotes metadata about the CHICKEN extension, such as author, license, and dependencies (and dependencies for tests).
+
+`srfi-117.setup`
+: This file tells the CHICKEN package manager (`chicken-install`) how to build the egg.
+
+`srfi-117.release-info`
+: Describes the URL / different releases of the CHICKEN extension.
+
+Additionally, the `tests/` directory has been added to accomodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `list-queues/` directory.
+
+## License
+
+Provided under a single clause BSD license, Copyright (C) John Cowan 2015. See LICENSE for full details.
+

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ While this repository is primarily to provide a reference implementation of SRFI
 `srfi-117.release-info`
 : Describes the URL / different releases of the CHICKEN extension.
 
-Additionally, the `tests/` directory has been added to accomodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `list-queues/` directory.
+Additionally, the `tests/` directory has been added to accommodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `list-queues/` directory.
 
 ## License
 

--- a/list-queues/list-queues-test.scm
+++ b/list-queues/list-queues-test.scm
@@ -1,5 +1,5 @@
 (cond-expand
-  (chicken (use test list-queues))
+  (chicken (use test srfi-117))
   (chibi (import (chibi test) (list-queues)))
 )
 

--- a/list-queues/list-queues.scm
+++ b/list-queues/list-queues.scm
@@ -1,4 +1,4 @@
-(module list-queues ()
+(module srfi-117 ()
   (import scheme)
   (import (only chicken include define-record-type case-lambda error))
   (export make-list-queue list-queue list-queue-copy list-queue-unfold list-queue-unfold-right)
@@ -9,5 +9,5 @@
   (export list-queue-append list-queue-append! list-queue-concatenate)
   (export list-queue-append list-queue-append! list-queue-concatenate)
   (export list-queue-map list-queue-map! list-queue-for-each)
-  (include "list-queues-impl.scm")
+  (include "list-queues/list-queues-impl.scm")
 )

--- a/list-queues/list-queues.sld
+++ b/list-queues/list-queues.sld
@@ -1,4 +1,4 @@
-(define-library (list-queues)
+(define-library (srfi-117)
   (import (scheme base) (scheme case-lambda))
   (export make-list-queue list-queue list-queue-copy list-queue-unfold list-queue-unfold-right)
   (export list-queue? list-queue-empty?)

--- a/srfi-117.meta
+++ b/srfi-117.meta
@@ -1,0 +1,18 @@
+;; -*- Hen -*-
+
+((egg "srfi-117.egg")
+ ; List of files that should be bundled alongside egg
+ (files "list-queues"
+        "tests"
+        "srfi-117.setup"
+        "srfi-117.meta"
+        "srfi-117.scm"
+        "LICENSE")
+
+ (license "BSD")
+ (category data)
+ (test-depends test)
+ (author "John Cowan")
+ (email "cowan@ccil.org")
+ (repo "https://github.com/scheme-requests-for-implementation/srfi-117")
+ (synopsis "List Queues."))

--- a/srfi-117.release-info
+++ b/srfi-117.release-info
@@ -1,0 +1,3 @@
+(repo git "git://github.com/scheme-requests-for-implementation/srfi-117.git")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-117/tar.gz/CHICKEN-{egg-release}")
+(release "1.0")

--- a/srfi-117.setup
+++ b/srfi-117.setup
@@ -1,0 +1,13 @@
+;; -*- Hen -*-
+
+(define (dynld-name fn)
+  (make-pathname #f fn ##sys#load-dynamic-extension))
+
+(compile -O3 -d0 -s list-queues/list-queues.scm -j srfi-117 -o srfi-117.so)
+(compile -O2 -d0 -s srfi-117.import.scm)
+
+(install-extension
+ 'srfi-117
+ `(,(dynld-name "srfi-117") ,(dynld-name "srfi-117.import"))
+ `((version "1.0")))
+

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,0 +1,1 @@
+(include "../list-queues/list-queues-test.scm")


### PR DESCRIPTION
Implements changes necessary for packaging SRFI 117 as an extension (aka egg) for CHICKEN Scheme (http://call-cc.org).

This work was requested by John Cowan in the #chicken channel on Freenode. For the sake of clarity, I go by DeeEff on Freenode, though not here.

I would first suggest that this be merged in as a separate branch, rather than on top of master, so as to reduce the file clutter for visitors who wish to see the implementation without wanting to see the CHICKEN specific packaging files. I do not know of any way to suggest such through the PR interface, but the following can be done:

```
Create a new branch on the main repo (call it CHICKEN)
I'll cancel this PR
I'll open a new PR to the new branch instead of on master.
```

Additionally, in order for this to work once it is accepted by the CHICKEN community into the list of available extensions, a tag will need to be created. It will need to be called CHICKEN-1.0. This can be done simply as follows (assuming you are on the CHICKEN branch where all the release files exist):

$ git tag CHICKEN-1.0
$ git push --tags

Afterwards, people should be able to install and use this SRFI from within CHICKEN Scheme. Contact me (Jeremy Steward) at jeremy@thatgeoguy.ca if more clarification is needed on any of the above.
