### PR TITLE
Fix test using a queue after passing it to list-queue-append!

### DIFF
--- a/list-queues/list-queues-test.scm
+++ b/list-queues/list-queues-test.scm
@@ -16,7 +16,7 @@
   (test-assert (list-queue? y))
   (define z (list-queue-append x y))
   (test '(1 2 3 4 5) (list-queue-list z))
-  (define z2 (list-queue-append! x y))
+  (define z2 (list-queue-append! x (list-queue-copy y)))
   (test '(1 2 3 4 5) (list-queue-list z2))
   (test 1 (list-queue-front z))
   (test 5 (list-queue-back z))


### PR DESCRIPTION
The SRFI text says you can't assume anything about the contents
of list-queues after they are passed to list-queue-append!, but
some tests refer to the queue (y) after it is used by
list-queue-append!.   This fixes it by passing a copy of y to
list-queue-append!.
