### PR TITLE
CHICKEN Packaging - version 1.1

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,19 @@
+Copyright (C) John Cowan (2015, 2016). All Rights Reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,31 @@
 # SRFI 117 - Mutable Queues
 
-This repository hosts a reference implementation of SRFI 117 - Mutable Queues. The full documentation for this SRFI can be found on the [SRFI Document Reference](http://srfi.schemers.org/srfi-117). The repository hosts a complete implementation of the SRFI, running on [CHICKEN](http://call-cc.org) Scheme.
+This repository hosts a reference implementation of SRFI 117 - Mutable Queues.
+The full documentation for this SRFI can be found on the [SRFI Document
+Reference](http://srfi.schemers.org/srfi-117). The repository hosts a complete
+implementation of the SRFI, running on [CHICKEN](http://call-cc.org) Scheme.
 
 ## File Description
 
-While this repository is primarily to provide a reference implementation of SRFI 117, it also currently serves as the base repository to host the library as a CHICKEN extension (egg). Thus, there are three files that are independent of the SRFI itself, and are as follows:
+While this repository is primarily to provide a reference implementation of
+SRFI 117, it also currently serves as the base repository to host the library
+as a CHICKEN extension (egg). Thus, there are three files that are independent
+of the SRFI itself, and are as follows:
 
-`srfi-117.meta`
-: This file denotes metadata about the CHICKEN extension, such as author, license, and dependencies (and dependencies for tests).
+`srfi-117.meta` : This file denotes metadata about the CHICKEN extension, such
+as author, license, and dependencies (and dependencies for tests).
 
-`srfi-117.setup`
-: This file tells the CHICKEN package manager (`chicken-install`) how to build the egg.
+`srfi-117.setup` : This file tells the CHICKEN package manager
+(`chicken-install`) how to build the egg.
 
-`srfi-117.release-info`
-: Describes the URL / different releases of the CHICKEN extension.
+`srfi-117.release-info` : Describes the URL / different releases of the CHICKEN
+extension.
 
-Additionally, the `tests/` directory has been added to accommodate the CHICKEN package manager (for running tests). Currently it provides a default test runner which merely includes the tests found in the `list-queues/` directory.
+Additionally, the `tests/` directory has been added to accommodate the CHICKEN
+package manager (for running tests). Currently it provides a default test
+runner which merely includes the tests found in the `list-queues/` directory.
 
 ## License
 
-Provided under a single clause BSD license, Copyright (C) John Cowan 2015. See LICENSE for full details.
-
+Provided under a single clause BSD license, Copyright (C) John Cowan (2015,
+2016). See LICENSE for full details.

--- a/srfi-117.meta
+++ b/srfi-117.meta
@@ -2,17 +2,21 @@
 
 ((egg "srfi-117.egg")
  ; List of files that should be bundled alongside egg
- (files "list-queues"
-        "tests"
+ (files "list-queues/list-queues.scm"
+        "list-queues/list-queues-impl.scm"
+        "list-queues/list-queues-test.scm"
+        "tests/run.scm"
         "srfi-117.setup"
         "srfi-117.meta"
-        "srfi-117.scm"
-        "LICENSE")
+        "srfi-117.release-info"
+        "LICENSE"
+        "README.md")
 
  (license "BSD")
  (category data)
  (test-depends test)
  (author "John Cowan")
+ (maintainer "Jeremy Steward")
  (email "cowan@ccil.org")
  (repo "https://github.com/scheme-requests-for-implementation/srfi-117")
  (synopsis "List Queues."))

--- a/srfi-117.release-info
+++ b/srfi-117.release-info
@@ -1,3 +1,7 @@
+(uri meta-file
+     "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.1")
+
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-117.git")
-(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-117/tar.gz/CHICKEN-{egg-release}")
-(release "1.0")
+(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-117/tar.gz/CHICKEN-{egg-release}" whole-repo)
+(release "1.0" whole-repo)

--- a/srfi-117.setup
+++ b/srfi-117.setup
@@ -3,11 +3,11 @@
 (define (dynld-name fn)
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
-(compile -O3 -d0 -s list-queues/list-queues.scm -j srfi-117 -o srfi-117.so)
+(compile -O3 -d0 -s -J list-queues/list-queues.scm -o srfi-117.so)
 (compile -O2 -d0 -s srfi-117.import.scm)
 
 (install-extension
  'srfi-117
  `(,(dynld-name "srfi-117") ,(dynld-name "srfi-117.import"))
- `((version "1.0")))
+ `((version "1.1")))
 


### PR DESCRIPTION
Hi Arthur, as per SRFI 113, 128, and 116, I have updated the meta/setup/release-info to allow it such that the CHICKEN extension can be installed without pulling every file down from the entire repository. 

I have likewise added an actual LICENSE file and updated the README accordingly.

If merged could you please add a tag CHICKEN-1.1 to the repo? Cheers. 
