### PR TITLE
Bumps version to reflect README changes.

### DIFF
--- a/srfi-117.meta
+++ b/srfi-117.meta
@@ -10,7 +10,7 @@
         "srfi-117.meta"
         "srfi-117.release-info"
         "LICENSE"
-        "README.md")
+        "README.org")
 
  (license "BSD")
  (category data)

--- a/srfi-117.release-info
+++ b/srfi-117.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.2")
 (release "1.1")
 
 (repo git "git://github.com/scheme-requests-for-implementation/srfi-117.git")

--- a/srfi-117.release-info
+++ b/srfi-117.release-info
@@ -1,5 +1,6 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+(release "1.3")
 (release "1.2")
 (release "1.1")
 

--- a/srfi-117.release-info
+++ b/srfi-117.release-info
@@ -1,6 +1,5 @@
 (uri meta-file
      "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
-(release "1.3")
 (release "1.2")
 (release "1.1")
 

--- a/srfi-117.setup
+++ b/srfi-117.setup
@@ -3,10 +3,10 @@
 (define (dynld-name fn)
   (make-pathname #f fn ##sys#load-dynamic-extension))
 
-(compile -O3 -d0 -s -J list-queues/list-queues.scm -o srfi-117.so)
+(compile -O3 -d0 -s -J list-queues/list-queues.scm -o ,(dynld-name "srfi-117"))
 (compile -O2 -d0 -s srfi-117.import.scm)
 
 (install-extension
  'srfi-117
  `(,(dynld-name "srfi-117") ,(dynld-name "srfi-117.import"))
- `((version "1.2")))
+ `((version "1.3")))

--- a/srfi-117.setup
+++ b/srfi-117.setup
@@ -9,5 +9,4 @@
 (install-extension
  'srfi-117
  `(,(dynld-name "srfi-117") ,(dynld-name "srfi-117.import"))
- `((version "1.1")))
-
+ `((version "1.2")))

--- a/srfi-117.setup
+++ b/srfi-117.setup
@@ -9,4 +9,4 @@
 (install-extension
  'srfi-117
  `(,(dynld-name "srfi-117") ,(dynld-name "srfi-117.import"))
- `((version "1.3")))
+ `((version "1.2")))


### PR DESCRIPTION
This should correspond to a tag for `CHICKEN-1.2`.

I merely bumped the version here to reflect the new README distributed with the SRFI.
