### PR TITLE
Fixes typo in SRFI HTML document

### DIFF
--- a/srfi-117.html
+++ b/srfi-117.html
@@ -98,7 +98,7 @@ Returns a newly allocated list queue containing the elements of <var>list-queue<
 <p>If <var>queue</var> is omitted, a newly allocated list queue is used.</p>
 
 <p>
-<tt>(list-queue-unfold-right </tt><var>stop? mapper successor seed</var><tt>)</tt>
+<tt>(list-queue-unfold-right </tt><var>stop? mapper successor seed</var> [ <var>queue</var> ]<tt>)</tt>
 </p>
 <p>Performs the following algorithm:</p>
 
@@ -189,13 +189,13 @@ Note: To apply a destructive list procedure to a list queue, use <tt>(list-queue
 <tt>(list-queue-append </tt><var>list-queue</var> ...<tt>)</tt>
 </p>
 <p>
-Returns a list queue which contains all the elements in front-to-back order from all the <var>list-queues</var> in front-to-back order.  The result does not share storage with any of the arguments.  This operation is O(n) in the total number of elements in all queues.  
+Returns a list queue which contains all the elements in front-to-back order from all the <var>list-queues</var> in front-to-back order.  The result does not share storage with any of the arguments.  This operation is O(n) in the total number of elements in all queues.
 </p>
 <p>
 <tt>(list-queue-append! </tt><var>list-queue</var> ...<tt>)</tt>
 </p>
 <p>
-Returns a list queue which contains all the elements in front-to-back order from all the <var>list-queues</var> in front-to-back order.  It is an error to assume anything about the contents of the <var>list-queues</var> after the procedure returns.  This operation is O(n) in the total number of queues, not elements.  
+Returns a list queue which contains all the elements in front-to-back order from all the <var>list-queues</var> in front-to-back order.  It is an error to assume anything about the contents of the <var>list-queues</var> after the procedure returns.  This operation is O(n) in the total number of queues, not elements.
 It is not part of the R7RS-small list API, but is included here for efficiency
 when pure functional append is not required.
 </p>
@@ -238,7 +238,7 @@ Applies <var>proc</var> to each element of <var>list-queue</var> in front-to-bac
 </ul>
 
 <H1>Copyright</H1>
-Copyright © John Cowan, 2014. All Rights Reserved. 
+Copyright © John Cowan, 2014. All Rights Reserved.
 <p>
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),

--- a/srfi-117.release-info
+++ b/srfi-117.release-info
@@ -1,8 +1,8 @@
 (uri meta-file
-     "https://raw.githubusercontent.com/scheme-requests-for-implementation/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
+     "https://raw.githubusercontent.com/ThatGeoGuy/{egg-name}/CHICKEN-{egg-release}/{egg-name}.meta")
 (release "1.2")
 (release "1.1")
 
-(repo git "git://github.com/scheme-requests-for-implementation/srfi-117.git")
-(uri targz "https://codeload.github.com/scheme-requests-for-implementation/srfi-117/tar.gz/CHICKEN-{egg-release}" whole-repo)
+(repo git "git://github.com/ThatGeoGuy/srfi-117.git")
+(uri targz "https://codeload.github.com/ThatGeoGuy/srfi-117/tar.gz/CHICKEN-{egg-release}" whole-repo)
 (release "1.0" whole-repo)


### PR DESCRIPTION
Hey Arthur, 

I noticed a typo (more just missing text) in the procedure signature of `list-queue-update-right`, so I added the missing parameter to the procedure definition. This doesn't change anything, but makes it so the signature matches the description below it as well as the implementation.

My editor (vim) also removed extraneous blank space at the end of lines (does this automatically), so it looks like I edited three or four lines when I only touched the one myself.

NOTE: You can more or less ignore the change that points the release-info to my fork. You can accept that commit or just reject it if you don't want to, it won't affect anything. All that does is tell CHICKEN's tooling to use my repo for tags / releases instead of yours.

Cheers,
